### PR TITLE
Add support for multiple simultaneous bot instances

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -2,7 +2,7 @@ const debug = require('debug')('kcapp-bot:bot');
 const sleep = require('./sleep');
 
 /** Array of Bogey numbers */
-exports.BOGEY_NUMBERS = [169, 168, 166, 165, 163, 162, 159];
+const BOGEY_NUMBERS = [169, 168, 166, 165, 163, 162, 159];
 
 /** Miss */
 const MISS = 0;
@@ -196,178 +196,181 @@ function isSuccessful(targetPercentage) {
     return Math.random() < targetPercentage;
 }
 
-/**
- * Undo the previous visit
- */
-exports.undoVisit = () => {
-    this.totalVisits--;
-}
+class Bot {
+    constructor(id, skill) {
+        this.id = id;
+        this.setup(skill);
+        this.visits = [];
+        this.totalVisits = 0;
+    }
 
-/**
- * Attempt a throw at the given number
- *
- * @param {int} number - Number we are aiming for
- * @param {int} multiplier - Multiplier we are aiming for
- */
-exports.attemptThrow = (number, multiplier) => {
-    let score = number;
-    const hitrate = this.bot.hitrates[multiplier];
-    if (!isSuccessful(hitrate)) {
-        if (multiplier == TRIPLE) {
-            // We either hit single, or adjacent
-            if (isSuccessful(this.bot.hitrates[SINGLE])) {
-                multiplier = SINGLE;
+    /**
+     * Undo the previous visit
+     */
+    undoVisit () {
+        this.totalVisits--;
+    }
+
+    /**
+     * Attempt a throw at the given number
+     *
+     * @param {int} number - Number we are aiming for
+     * @param {int} multiplier - Multiplier we are aiming for
+     */
+    attemptThrow (number, multiplier) {
+        let score = number;
+        const hitrate = this.bot.hitrates[multiplier];
+        if (!isSuccessful(hitrate)) {
+            if (multiplier == TRIPLE) {
+                // We either hit single, or adjacent
+                if (isSuccessful(this.bot.hitrates[SINGLE])) {
+                    multiplier = SINGLE;
+                } else {
+                    score = getRandom(getAdjacent(BOARD, BOARD.indexOf(score), this.bot.miss_range));
+                    multiplier = SINGLE;
+                }
+            } else if (multiplier === DOUBLE) {
+                // We either hit miss, or single
+                if (isSuccessful(this.bot.hitrates[MISS])) {
+                    score = 0;
+                    multiplier = SINGLE;
+                } else {
+                    multiplier = SINGLE;
+                }
             } else {
+                // We hit adajcent
                 score = getRandom(getAdjacent(BOARD, BOARD.indexOf(score), this.bot.miss_range));
-                multiplier = SINGLE;
+                multiplier = getRandom(getAdjacent(BOARD_MULTIPLIERS, BOARD_MULTIPLIERS.indexOf(multiplier), 1));
             }
-        } else if (multiplier === DOUBLE) {
-            // We either hit miss, or single
-            if (isSuccessful(this.bot.hitrates[MISS])) {
-                score = 0;
-                multiplier = SINGLE;
+        }
+        const dart = { score: score, multiplier: multiplier };
+        debug(`Throw ${JSON.stringify(dart)}`);
+        return dart;
+    }
+
+    /**
+     * Attempt to checkout based on the current score
+     *
+     * @param {int} - Current score
+     * @param {int} - Number of darts thrown
+     */
+    attemptCheckout (currentScore, thrown) {
+        const darts = [];
+        if (currentScore > 40) {
+            const checkout = CHECKOUT_GUIDE[currentScore];
+            if (3 - thrown >= checkout.length) {
+                debug(`Trying for a big checkout: ${currentScore}`);
+                for (let i = thrown; i < checkout.length; i++) {
+                    const dart = this.attemptThrow(checkout[i].score, checkout[i].multiplier);
+                    darts.push(dart);
+                    if (!isEqual(dart, checkout[i])) {
+                        break;
+                    }
+                    currentScore -= dart.score * dart.multiplier;
+                    if (currentScore <= 0) {
+                        break;
+                    }
+                }
             } else {
-                multiplier = SINGLE;
+                debug("We don't have enough darts, just score");
+                // We cannot complete a perfect checkout, so lets just score some points
+                // TODO improve
+                for (let i = thrown; i < 3; i++) {
+                    const dart = this.attemptThrow(20, 1);
+                    darts.push(dart);
+                    currentScore -= dart.score * dart.multiplier;
+                    if (currentScore <= 1) {
+                        break;
+                    }
+                }
             }
         } else {
-            // We hit adajcent
-            score = getRandom(getAdjacent(BOARD, BOARD.indexOf(score), this.bot.miss_range));
-            multiplier = getRandom(getAdjacent(BOARD_MULTIPLIERS, BOARD_MULTIPLIERS.indexOf(multiplier), 1));
-        }
-    }
-    const dart = { score: score, multiplier: multiplier };
-    debug(`Throw ${JSON.stringify(dart)}`);
-    return dart;
-}
-
-/**
- * Attempt to checkout based on the current score
- *
- * @param {int} - Current score
- * @param {int} - Number of darts thrown
- */
-exports.attemptCheckout = (currentScore, thrown) => {
-    const darts = [];
-    if (currentScore > 40) {
-        const checkout = CHECKOUT_GUIDE[currentScore];
-        if (3 - thrown >= checkout.length) {
-            debug(`Trying for a big checkout: ${currentScore}`);
-            for (let i = thrown; i < checkout.length; i++) {
-                const dart = this.attemptThrow(checkout[i].score, checkout[i].multiplier);
+            // Only attempt checkout if we have an even number
+            while (currentScore % 2 !== 0) {
+                const dart = this.attemptThrow(1, 1);
                 darts.push(dart);
-                if (!isEqual(dart, checkout[i])) {
-                    break;
-                }
                 currentScore -= dart.score * dart.multiplier;
                 if (currentScore <= 0) {
                     break;
                 }
             }
-        } else {
-            debug("We don't have enough darts, just score");
-            // We cannot complete a perfect checkout, so lets just score some points
-            // TODO improve
-            for (let i = thrown; i < 3; i++) {
-                const dart = this.attemptThrow(20, 1);
-                darts.push(dart);
-                currentScore -= dart.score * dart.multiplier;
-                if (currentScore <= 1) {
-                    break;
-                }
-            }
-        }
-    } else {
-        // Only attempt checkout if we have an even number
-        while (currentScore % 2 !== 0) {
-            const dart = this.attemptThrow(1, 1);
-            darts.push(dart);
-            currentScore -= dart.score * dart.multiplier;
-            if (currentScore <= 0) {
-                break;
-            }
-        }
 
-        if (currentScore > 1) {
-            debug(`Score is ${currentScore}, trying to checkout`);
-            for (let i = thrown; i < 3; i++) {
-                if (currentScore % 2 === 0) {
-                    const dart = this.attemptThrow(currentScore / 2, 2);
-                    darts.push(dart);
-                    currentScore -= dart.score * dart.multiplier;
-                    if (currentScore <= 0) {
-                        break;
-                    }
-                } else {
-                    const dart = this.attemptThrow(1, 1);
-                    darts.push(dart);
-                    currentScore -= dart.score * dart.multiplier;
-                    if (currentScore <= 0) {
-                        break;
+            if (currentScore > 1) {
+                debug(`Score is ${currentScore}, trying to checkout`);
+                for (let i = thrown; i < 3; i++) {
+                    if (currentScore % 2 === 0) {
+                        const dart = this.attemptThrow(currentScore / 2, 2);
+                        darts.push(dart);
+                        currentScore -= dart.score * dart.multiplier;
+                        if (currentScore <= 0) {
+                            break;
+                        }
+                    } else {
+                        const dart = this.attemptThrow(1, 1);
+                        darts.push(dart);
+                        currentScore -= dart.score * dart.multiplier;
+                        if (currentScore <= 0) {
+                            break;
+                        }
                     }
                 }
             }
         }
-    }
-    return darts;
-}
-
-/**
- * Score a visit
- * @param {object} - Socket for scoring
- */
-exports.score = async (socket) => {
-    if (this.visits[this.totalVisits]) {
-        const visit = this.visits[this.totalVisits];
-        // We have a previous visit, just re use it
-        socket.emitThrow(visit[0]);
-        await sleep(100);
-        socket.emitThrow(visit[1]);
-        await sleep(100);
-        socket.emitThrow(visit[2]);
-        await sleep(100);
-        this.totalVisits++;
-        return;
+        return darts;
     }
 
-    const player = socket.currentPlayer;
-    let thrown = 0;
-    while (thrown < 3 && player.current_score > 0) {
-        if (player.current_score > 170 || this.BOGEY_NUMBERS.includes(player.current_score)) {
-            const dart = this.attemptThrow(20, 3);
-            socket.emitThrow(dart);
+    /**
+     * Create a new bot with the given skill
+     * @param {int} - Skill level of the bot
+     */
+    setup(botSkill) {
+        this.bot = botSkill;
+        debug(`Configured "${this.bot.name}" bot => ${JSON.stringify(this.bot)}`);
+    }
+
+    /**
+     * Score a visit
+     * @param {object} - Socket for scoring
+     */
+    async score (socket) {
+        if (this.visits[this.totalVisits]) {
+            const visit = this.visits[this.totalVisits];
+            // We have a previous visit, just re use it
+            socket.emitThrow(visit[0]);
             await sleep(100);
-            thrown++;
-        } else {
-            const darts = this.attemptCheckout(player.current_score, thrown);
-            for (let i = 0; i < darts.length; i++) {
-                const dart = darts[i];
-                player.current_score -= dart.score * dart.multiplier;
+            socket.emitThrow(visit[1]);
+            await sleep(100);
+            socket.emitThrow(visit[2]);
+            await sleep(100);
+            this.totalVisits++;
+            return;
+        }
+
+        const player = socket.currentPlayer;
+        let thrown = 0;
+        while (thrown < 3 && player.current_score > 0) {
+            if (player.current_score > 170 || BOGEY_NUMBERS.includes(player.current_score)) {
+                const dart = this.attemptThrow(20, 3);
                 socket.emitThrow(dart);
                 await sleep(100);
-                if (player.current_score <= 1) {
-                    break;
+                thrown++;
+            } else {
+                const darts = this.attemptCheckout(player.current_score, thrown);
+                for (let i = 0; i < darts.length; i++) {
+                    const dart = darts[i];
+                    player.current_score -= dart.score * dart.multiplier;
+                    socket.emitThrow(dart);
+                    await sleep(100);
+                    if (player.current_score <= 1) {
+                        break;
+                    }
                 }
+                thrown += darts.length;
             }
-            thrown += darts.length;
         }
+        this.totalVisits++;
+        this.visits.push(socket.throws);
     }
-    this.totalVisits++;
-    this.visits.push(socket.throws);
 }
 
-/**
- * Create a new bot with the given skill
- * @param {int} - Skill level of the bot
- */
-exports.setup = (botSkill) => {
-    this.bot = botSkill;
-    debug(`Configured "${this.bot.name}" bot => ${JSON.stringify(this.bot)}`);
-}
-
-module.exports = (id, skill) => {
-    this.id = id;
-    this.setup(skill);
-    this.visits = [];
-    this.totalVisits = 0;
-    return this;
-}
+module.exports = Bot;

--- a/kcapp-bot.js
+++ b/kcapp-bot.js
@@ -2,79 +2,89 @@ const debug = require('debug')('kcapp-bot:main');
 const decache = require('decache');
 const sleep = require('./sleep');
 
-let firstThrow = true;
-
-async function doScore(socket, bot) {
-    const player = socket.currentPlayer;
-    if (player.player_id === bot.id) {
-        if (firstThrow) {
-            debug(`Waiting because of first throw`);
-            await sleep(5000); // wait for page to load
-        }
-        await sleep(500);
-        await bot.score(socket);
-        await sleep(1000);
-        socket.emitVisit();
+class KcappBot {
+    constructor(botId, sioURL, sioPort = 3000, apiURL = 'http://localhost:8001', protocol = 'http') {
+        this.botId = botId;
+        this.sioURL = sioURL;
+        this.sioPort = sioPort;
+        this.apiURL = apiURL;
+        this.protocol = protocol;
+        this.firstThrow = true;
     }
-    firstThrow = false;
+
+    async doScore(socket, bot) {
+        const player = socket.currentPlayer;
+        if (player.player_id === bot.id) {
+            if (this.firstThrow) {
+                debug(`Waiting because of first throw`);
+                await sleep(5000); // wait for page to load
+            }
+            await sleep(500);
+            await bot.score(socket);
+            await sleep(1000);
+            socket.emitVisit();
+        }
+        this.firstThrow = false;
+    }
+
+    async handleScoreUpdate(socket, data, bot) {
+        const leg = data.leg;
+        if (leg.is_finished) {
+            return;
+        } else if (leg.current_player_id !== bot.id) {
+            debug(`[${leg.id}] Not our turn, waiting...`);
+        } else if (data.is_undo) {
+            debug(`[${leg.id}] Recevied undo visit, forwarding`);
+            bot.undoVisit();
+            socket.emit('undo_visit', {});
+        } else {
+            this.doScore(socket, bot);
+        }
+    }
+
+    playLeg(legId, botSkill) {
+        const SkillBot = require('./bot');
+        const bot = new SkillBot(this.botId, botSkill);
+
+        const kcapp = require('kcapp-sio-client/kcapp')(this.sioURL, this.sioPort, 'kcapp-bot', this.protocol);
+         // Make sure we get a separate instance for each leg we connect to...
+        decache('kcapp-sio-client/kcapp');
+        kcapp.connectLegNamespace(legId, (socket) => {
+            debug(`[${legId}] kcapp-bot connected to leg`);
+            this.firstThrow = true;
+
+            socket.on('score_update', (data) => {
+                this.handleScoreUpdate(socket, data, bot);
+            });
+            socket.on('leg_finished', (data) => {
+                debug(`[${legId}] Leg is finished`);
+                socket.disconnect();
+            });
+            this.doScore(socket, bot);
+        });
+    }
+
+    replayLeg(legId, playerId, startingScore = 301) {
+        const ReplayBot = require('./replay-bot')
+        const bot = new ReplayBot(this.botId, legId, playerId, this.apiURL, startingScore);
+
+        const kcapp = require('kcapp-sio-client/kcapp')(this.sioURL, this.sioPort, 'kcapp-bot', this.protocol);
+         // Make sure we get a separate instance for each leg we connect to...
+        decache('kcapp-sio-client/kcapp');
+        kcapp.connectLegNamespace(legId, (socket) => {
+            debug(`[${legId}] replay-bot connected to leg`);
+            this.firstThrow = true;
+
+            socket.on('score_update', (data) => {
+                this.handleScoreUpdate(socket, data, bot);
+            });
+            socket.on('leg_finished', (data) => {
+                debug(`[${legId}] Leg is finished`);
+                socket.disconnect();
+            });
+            this.doScore(socket, bot);
+        });
+    }
 }
 
-async function handleScoreUpdate(socket, data, bot) {
-    const leg = data.leg;
-    if (leg.is_finished) {
-        return;
-    } else if (leg.current_player_id !== bot.id) {
-        debug(`[${leg.id}] Not our turn, waiting...`);
-    } else if (data.is_undo) {
-        debug(`[${leg.id}] Recevied undo visit, forwarding`);
-        bot.undoVisit();
-        socket.emit('undo_visit', {});
-    } else {
-        doScore(socket, bot);
-    }
-}
-
-module.exports = (botId, sioURL, sioPort = 3000, apiURL = 'http://localhost:8001', protocol = 'http') => {
-    return {
-        playLeg: (legId, botSkill) => {
-            const bot = require('./bot')(botId, botSkill);
-
-            const kcapp = require('kcapp-sio-client/kcapp')(sioURL, sioPort, 'kcapp-bot', protocol);
-             // Make sure we get a separate instance for each leg we connect to...
-            decache('kcapp-sio-client/kcapp');
-            kcapp.connectLegNamespace(legId, (socket) => {
-                debug(`[${legId}] kcapp-bot connected to leg`);
-                firstThrow = true;
-
-                socket.on('score_update', (data) => {
-                    handleScoreUpdate(socket, data, bot);
-                });
-                socket.on('leg_finished', (data) => {
-                    debug(`[${legId}] Leg is finished`);
-                    socket.disconnect();
-                });
-                doScore(socket, bot);
-            });
-        },
-        replayLeg: (legId, playerId, startingScore = 301) => {
-            const bot = require('./replay-bot')(botId, legId, playerId, apiURL, startingScore);
-
-            const kcapp = require('kcapp-sio-client/kcapp')(sioURL, sioPort, 'kcapp-bot', protocol);
-             // Make sure we get a separate instance for each leg we connect to...
-            decache('kcapp-sio-client/kcapp');
-            kcapp.connectLegNamespace(legId, (socket) => {
-                debug(`[${legId}] replay-bot connected to leg`);
-                firstThrow = true;
-
-                socket.on('score_update', (data) => {
-                    handleScoreUpdate(socket, data, bot);
-                });
-                socket.on('leg_finished', (data) => {
-                    debug(`[${legId}] Leg is finished`);
-                    socket.disconnect();
-                });
-                doScore(socket, bot);
-            });
-        }
-    };
-};
+module.exports = KcappBot;

--- a/replay-bot.js
+++ b/replay-bot.js
@@ -2,90 +2,94 @@ const axios = require('axios');
 const debug = require('debug')('kcapp-bot:replay-bot');
 const sleep = require('./sleep');
 
-/**
- * Create a new replay-bot which will replay a random leg for the given player
- * @param {int} - PlayerID of the given player
- * @param {string} - Base URL of kcapp API
- * @param {int} - Starting score of the leg
- */
-exports.setup = (playerId, legId, apiURL, startingScore) => {
-    debug(`[${legId}] Requesting leg to replay for ${playerId}`)
-    axios.get(`${apiURL}/player/${playerId}/random/${startingScore}`)
-        .then(response => {
-            const visits = response.data;
-            this.visits = visits;
-            debug(`[${legId}] Configured bot for leg ${visits[0].leg_id}`);
-        }).catch(error => {
-            debug(`Error when getting match: ${error}`);
-        });
-}
-
-/**
- * Get the next visit to use for scoring
- */
-exports.getVisit = () => {
-    const visit = this.visits.shift();
-    this.visitsThrown.push(visit);
-    return visit;
-}
-
-/**
- * Undo the previous visit
- */
-exports.undoVisit = () => {
-    const visit = this.visitsThrown.pop()
-    this.visits.unshift(visit);
-}
-
-/**
- * Get the correct dart to throw
- * @param {object} - Visit
- * @param {int} - Number of darts thrown
- */
-exports.attemptThrow = (visit, dartsThrown) => {
-    let dart = { score: visit.first_dart.value, multiplier: visit.first_dart.multiplier };
-    if (dartsThrown === 1) {
-        dart = { score: visit.second_dart.value, multiplier: visit.second_dart.multiplier };
-    } else if (dartsThrown == 2) {
-        dart = { score: visit.third_dart.value, multiplier: visit.third_dart.multiplier };
+class Bot {
+    /**
+     * @param {int} - Bot ID
+     * @param {int} - Leg ID
+     * @param {int} - Player ID
+     * @param {string} - kcapp API URL
+     * @param {int} - Starting score of leg
+     */
+    constructor(id, legId, playerId, apiURL, startingScore) {
+        this.id = id;
+        this.legId = legId;
+        this.setup(playerId, legId, apiURL, startingScore);
+        this.visits = [];
+        this.visitsThrown = [];
+        return this;
     }
-    debug(`[${this.legId}] Throw ${JSON.stringify(dart)}`);
-    return dart;
-}
 
-/**
- * Score a visit
- * @param {object} - Socket for scoring
- */
-exports.score = async (socket) => {
-    const visit = this.getVisit();
-    const first = this.attemptThrow(visit, 0);
-    socket.emitThrow(first);
-    await sleep(100);
-    const second = this.attemptThrow(visit, 1);
-    if (second.score) {
-        socket.emitThrow(second);
+    /**
+     * Create a new replay-bot which will replay a random leg for the given player
+     * @param {int} - PlayerID of the given player
+     * @param {string} - Base URL of kcapp API
+     * @param {int} - Starting score of the leg
+     */
+    setup(playerId, legId, apiURL, startingScore) {
+        debug(`[${legId}] Requesting leg to replay for ${playerId}`)
+        axios.get(`${apiURL}/player/${playerId}/random/${startingScore}`)
+            .then(response => {
+                const visits = response.data;
+                this.visits = visits;
+                debug(`[${legId}] Configured bot for leg ${visits[0].leg_id}`);
+            }).catch(error => {
+                debug(`Error when getting match: ${error}`);
+            });
+    }
+
+    /**
+     * Get the next visit to use for scoring
+     */
+    getVisit() {
+        const visit = this.visits.shift();
+        this.visitsThrown.push(visit);
+        return visit;
+    }
+
+    /**
+     * Undo the previous visit
+     */
+    undoVisit() {
+        const visit = this.visitsThrown.pop()
+        this.visits.unshift(visit);
+    }
+
+    /**
+     * Get the correct dart to throw
+     * @param {object} - Visit
+     * @param {int} - Number of darts thrown
+     */
+    attemptThrow(visit, dartsThrown) {
+        let dart = { score: visit.first_dart.value, multiplier: visit.first_dart.multiplier };
+        if (dartsThrown === 1) {
+            dart = { score: visit.second_dart.value, multiplier: visit.second_dart.multiplier };
+        } else if (dartsThrown == 2) {
+            dart = { score: visit.third_dart.value, multiplier: visit.third_dart.multiplier };
+        }
+        debug(`[${this.legId}] Throw ${JSON.stringify(dart)}`);
+        return dart;
+    }
+
+    /**
+     * Score a visit
+     * @param {object} - Socket for scoring
+     */
+    async score(socket) {
+        const visit = this.getVisit();
+        const first = this.attemptThrow(visit, 0);
+        socket.emitThrow(first);
         await sleep(100);
-    }
-    const third = this.attemptThrow(visit, 2);
-    if (third.score) {
-        socket.emitThrow(third);
-        await sleep(100);
+        const second = this.attemptThrow(visit, 1);
+        if (second.score) {
+            socket.emitThrow(second);
+            await sleep(100);
+        }
+        const third = this.attemptThrow(visit, 2);
+        if (third.score) {
+            socket.emitThrow(third);
+            await sleep(100);
+        }
     }
 }
 
-/**
- * @param {int} - Bot ID
- * @param {int} - Leg ID
- * @param {int} - Player ID
- * @param {string} - kcapp API URL
- * @param {int} - Starting score of leg
- */
-module.exports = (id, legId, playerId, apiURL, startingScore) => {
-    this.id = id;
-    this.legId = legId;
-    this.setup(playerId, legId, apiURL, startingScore);
-    this.visits = [];
-    this.visitsThrown = [];
-    return this;
-}
+module.exports = Bot;


### PR DESCRIPTION
This PR restructures the different types of bots into JS classes to enable using multiple bot instances simultaneously.
Rather than using e.g.
```JavaScript
const bot = require('kcapp-bot/kcapp-bot')(param1, param2, ...)
```
something like this is now needed to create a new bot instance:
```JavaScript
const KcappBot = require('kcapp-bot/kcapp-bot')
const bot = new KcappBot(param1, param2, ...)
```

---

This change can be used in https://github.com/kcapp/frontend in [`routes/lib/socketio_handler.js`](https://github.com/kcapp/frontend/blob/develop/routes/lib/socketio_handler.js) by adding a global require statement at the top and replacing the previous instantiation of the bot by something similar to the code snippet above:
```JavaScript
// at the top of the file along with the other require statements
const KcappBot = require('kcapp-bot/kcapp-bot')

...

// in line 122 in setupLegsNamespace()
const bot = new KcappBot(player.id, "localhost", 3000, `${app.locals.kcapp.api}`)
```

This is actually the only change needed in the frontend to use this PR.

This PR was tested with two simultaneous skill-based BO1 practices and two simultaneous mock-based BO1 practices. I haven't tested other match modes or combinations of simultaneous practices.